### PR TITLE
feat(optional): add support to map from optional to required property

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,45 @@ abstract class DogMapper {
 class DogMapperImpl extends DogMapper {...}
 ```
 
+## Optional  to Required
+If target class property is not optional but source property is mapping will fail in case of null value. 
+
+You can avoid this by specifying `defaultValue` property in `@Mapping` annotation.
+```dart
+class NullablePropertiesTarget {
+  final String text;
+  final num number;
+
+  NullablePropertiesTarget(this.text, this.number);
+}
+
+class NullablePropertiesSource {
+  final String? text;
+  final num? number;
+
+  NullablePropertiesSource(this.text, this.number);
+}
+
+abstract class NullablePropertiesMapper {
+  @Mapping(source: 'number', target: 'number', defaultValue: '0')
+  NullablePropertiesTarget fromSource(NullablePropertiesSource source);
+}
+```
+
+Will produce:
+```dart
+class NullablePropertiesMapperImpl extends NullablePropertiesMapper {
+  NullablePropertiesMapperImpl() : super();
+
+  @override
+  NullablePropertiesTarget fromSource(NullablePropertiesSource source) {
+    assert(source.text != null, 'text cannot be blank');
+    final nullablepropertiestarget =
+        NullablePropertiesTarget(source.text!, source.number ?? 0);
+    return nullablepropertiestarget;
+  }
+}
+```
 # Examples
 
 Please refer to the [example](https://github.com/smotastic/smartstruct/tree/master/example) package, for a list of examples and how to use the Mapper Annotation.

--- a/example/lib/complete/complete.mapper.g.dart
+++ b/example/lib/complete/complete.mapper.g.dart
@@ -12,6 +12,10 @@ class ExampleMapperImpl extends ExampleMapper {
 
   @override
   BarTarget fromFoo(FooSource source) {
+    assert(source.setterNumber != null, 'setterNumber cannot be blank');
+    assert(source.setterNumber != null, 'setterNumber cannot be blank');
+    assert(source.setterText != null, 'setterText cannot be blank');
+    assert(source.setterText != null, 'setterText cannot be blank');
     final bartarget = BarTarget(source.number, source.text, source.truthy,
         named: source.named,
         namedTwoDiff: source.namedTwo,

--- a/example/lib/nullable/nullable.dart
+++ b/example/lib/nullable/nullable.dart
@@ -1,0 +1,25 @@
+import 'package:smartstruct/smartstruct.dart';
+
+part 'nullable.mapper.g.dart';
+
+class Foo {
+  final String fooBar;
+  final String fooBar2;
+
+  Foo(this.fooBar, this.fooBar2);
+}
+
+class Bar {
+  final String? fooBar;
+  final String? fooBar2;
+
+  Bar(this.fooBar, this.fooBar2);
+}
+
+
+/// Mapper showcasing mapping from optional to required field with defaultValue
+@Mapper()
+abstract class FooBarMapper {
+  @Mapping(source: 'fooBar', target: 'fooBar', defaultValue: "''")
+  Foo fromBar(Bar bar);
+}

--- a/example/lib/nullable/nullable.mapper.g.dart
+++ b/example/lib/nullable/nullable.mapper.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'simple.dart';
+part of 'nullable.dart';
 
 // **************************************************************************
 // MapperGenerator
@@ -10,18 +10,9 @@ class FooBarMapperImpl extends FooBarMapper {
   FooBarMapperImpl() : super();
 
   @override
-  Bar? fromFoo(Foo? foo) {
-    if (foo == null) {
-      return null;
-    }
-    ;
-    final bar = Bar(foo.fooBar);
-    return bar;
-  }
-
-  @override
   Foo fromBar(Bar bar) {
-    final foo = Foo(bar.fooBar);
+    assert(bar.fooBar2 != null, 'fooBar2 cannot be blank');
+    final foo = Foo(bar.fooBar ?? '', bar.fooBar2!);
     return foo;
   }
 }

--- a/example/lib/simple/simple.mapper.g.dart
+++ b/example/lib/simple/simple.mapper.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'simple.dart';
+part of 'nullable.dart';
 
 // **************************************************************************
 // MapperGenerator

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -319,16 +319,16 @@ packages:
   smartstruct:
     dependency: "direct main"
     description:
-      name: smartstruct
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../smartstruct"
+      relative: true
+    source: path
     version: "1.2.3+1"
   smartstruct_generator:
     dependency: "direct dev"
     description:
-      name: smartstruct_generator
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../generator"
+      relative: true
+    source: path
     version: "1.2.3+1"
   source_gen:
     dependency: transitive

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
 publish_to: none
 dependencies:
   injectable: ^1.4.1
-  smartstruct: ^1.2.3+1
-  # smartstruct:
-  #   path: ../smartstruct
+  #smartstruct: ^1.2.3+1
+  smartstruct:
+     path: ../smartstruct
 dev_dependencies:
   build_runner: ^2.0.4
   injectable_generator: ^1.4.1
-  smartstruct_generator: ^1.2.3+1
-  # smartstruct_generator:
-  #   path: ../generator
+ # smartstruct_generator: ^1.2.3+1
+  smartstruct_generator:
+    path: ../generator

--- a/generator/lib/code_builders/assignment_builder.dart
+++ b/generator/lib/code_builders/assignment_builder.dart
@@ -2,6 +2,8 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
 
+import '../mapper_config.dart';
+
 /// Generates an assignment of a reference to a sourcefield.
 ///
 /// The assignment is the property {sourceField} of the given [Reference] {sourceReference}.
@@ -19,8 +21,17 @@ Expression generateSourceFieldAssignment(
     Reference sourceReference,
     dynamic sourceField,
     ClassElement classElement,
-    VariableElement targetField) {
+    VariableElement targetField,
+    MethodElement method) {
+  var defaultValues = MapperConfig.readDefaultValueConfig(method);
   var sourceFieldAssignment = sourceReference.property(sourceField.name);
+  if(sourceField.toString().contains('?') && !targetField.toString().contains('?')){
+    if(defaultValues.containsKey(sourceField.name)){
+      sourceFieldAssignment = sourceReference.property(sourceField.name + ' ?? ' + defaultValues[sourceField.name]);
+    } else {
+      sourceFieldAssignment = sourceReference.property(sourceField.name + '!');
+    }
+  }
   // list support
   if (sourceField.type.isDartCoreList || sourceField.type.isDartCoreIterable) {
     final sourceListType = _getGenericTypes(sourceField.type).first;

--- a/generator/lib/code_builders/method_builder.dart
+++ b/generator/lib/code_builders/method_builder.dart
@@ -72,7 +72,7 @@ Code _generateBody(Map<String, dynamic> config, MethodElement method,
   for(var accessor in sourceClass.accessors){
     if (accessor.toString().contains('?') && !defaultValues.containsKey(accessor.name)) {
       blockBuilder.addExpression(refer(
-          "assert(source.${accessor.name} != null, '${accessor.name} cannot be blank')"
+          "assert(${sourceParam.displayName}.${accessor.displayName} != null, '${accessor.displayName} cannot be blank')"
       ));
     }
   }

--- a/generator/lib/mapper_config.dart
+++ b/generator/lib/mapper_config.dart
@@ -13,7 +13,10 @@ class MapperConfig {
         mappingClass.metadata[0].element!.enclosingElement as ClassElement;
     final config = <String, dynamic>{};
     mapper.fields.forEach((field) {
-      final configField = annotation.read(field.name).literalValue;
+      var value = annotation.read(field.name);
+      final configField = value.isLiteral
+          ? annotation.read(field.name).literalValue
+          : annotation.read(field.name).objectValue;
       config.putIfAbsent(field.name, () => configField);
     });
     return config;
@@ -27,8 +30,22 @@ class MapperConfig {
 
     annotations.forEach((element) {
       var reader = ConstantReader(element);
-      config[reader.read('source').objectValue] =
-          reader.read('target').stringValue;
+      config[reader.read('source').objectValue] = reader.read('target').stringValue;
+    });
+    return config;
+  }
+  /// Reads the attributes of the [Mapping] annotations of a given Method,
+  /// and returns key value pairs, where the key is the source, and the value is the default value
+  static Map<String, String> readDefaultValueConfig(MethodElement method) {
+    final config = <String, String>{};
+    final annotations = TypeChecker.fromRuntime(Mapping).annotationsOf(method);
+
+    annotations.forEach((element) {
+      var reader = ConstantReader(element);
+      var property = reader.read('defaultValue');
+      if(property.isString) {
+        config[reader.read('source').stringValue] = property.stringValue;
+      }
     });
     return config;
   }

--- a/generator/pubspec.lock
+++ b/generator/pubspec.lock
@@ -333,9 +333,9 @@ packages:
   smartstruct:
     dependency: "direct main"
     description:
-      name: smartstruct
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../smartstruct"
+      relative: true
+    source: path
     version: "1.2.3+1"
   source_gen:
     dependency: "direct main"

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -17,4 +17,3 @@ dependencies:
   smartstruct:
     path: '../smartstruct'
   path: ^1.8.0
- 

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   build: ^2.0.2
   source_gen: ^1.0.1
   code_builder: ^4.0.0
-  smartstruct: ^1.2.3+1
+  smartstruct:
+    path: '../smartstruct'
   path: ^1.8.0
  

--- a/generator/test/mapper_test.dart
+++ b/generator/test/mapper_test.dart
@@ -17,6 +17,7 @@ Future<void> main() async {
 }
 
 const _expectedAnnotatedTests = {
+  'NullablePropertiesMapper',
   'theAnswer',
   'NoReturnTypeMapper',
   'SimpleMapper',

--- a/generator/test/src/mapper_test_input.dart
+++ b/generator/test/src/mapper_test_input.dart
@@ -8,6 +8,7 @@ part 'case_sensitive_mapper_input.dart';
 part 'list_mapper_input.dart';
 part 'constructor_mapper_input.dart';
 part 'function_mapper_input.dart';
+part 'nullable_properties_mapper_input.dart';
 
 @ShouldThrow('theAnswer is not a class and cannot be annotated with @Mapper')
 @Mapper()

--- a/generator/test/src/nullable_properties_mapper_input.dart
+++ b/generator/test/src/nullable_properties_mapper_input.dart
@@ -1,0 +1,35 @@
+part of 'mapper_test_input.dart';
+
+class NullablePropertiesTarget {
+  final String text;
+  final num number;
+
+  NullablePropertiesTarget(this.text, this.number);
+}
+
+class NullablePropertiesSource {
+  final String? text;
+  final num? number;
+
+  NullablePropertiesSource(this.text, this.number);
+}
+
+@Mapper()
+@ShouldGenerate(r'''
+class NullablePropertiesMapperImpl extends NullablePropertiesMapper {
+  NullablePropertiesMapperImpl() : super();
+
+  @override
+  NullablePropertiesTarget fromSource(NullablePropertiesSource source) {
+    assert(source.text != null, 'text cannot be blank');
+    final nullablepropertiestarget =
+        NullablePropertiesTarget(source.text!, source.number ?? 0);
+    return nullablepropertiestarget;
+  }
+}
+''')
+abstract class NullablePropertiesMapper {
+  @Mapping(source: 'number', target: 'number', defaultValue: '0')
+  NullablePropertiesTarget fromSource(NullablePropertiesSource source);
+}
+

--- a/smartstruct/lib/src/annotations.dart
+++ b/smartstruct/lib/src/annotations.dart
@@ -5,7 +5,10 @@ class Mapper {
   final bool useInjection;
   final bool caseSensitiveFields;
 
-  const Mapper({this.useInjection = false, this.caseSensitiveFields = false});
+  const Mapper({
+    this.useInjection = false,
+    this.caseSensitiveFields = false
+  });
 }
 
 const mapper = Mapper();
@@ -16,5 +19,10 @@ const mapper = Mapper();
 class Mapping {
   final dynamic source;
   final String target;
-  const Mapping({required this.source, required this.target});
+  final String? defaultValue;
+  const Mapping({
+    required this.source,
+    required this.target,
+    this.defaultValue
+  });
 }


### PR DESCRIPTION
**This is early version of the PR, i'd really enjoy feedback from you!**

**Api Changes:**
* added optional defaultValue property in @Mapping annotation.  (No breaking changes)

**Current state:**
Added support for mapping from optional to required property, if source value is null, defaultValue will be used, otherwise mapping will fail.

**Previous State:**
If tired to map from optional to required it generates uncompilable code


Example:
```dart
@Mapper
abstract class NullablePropertiesMapper {
  @Mapping(source: 'number', target: 'number', defaultValue: '0')
  NullablePropertiesTarget fromSource(NullablePropertiesSource source);
}
```

will produce:

```dart
class NullablePropertiesMapperImpl extends NullablePropertiesMapper {
  NullablePropertiesMapperImpl() : super();

  @override
  NullablePropertiesTarget fromSource(NullablePropertiesSource source) {
    assert(source.text != null, 'text cannot be blank');
    final nullablepropertiestarget =
        NullablePropertiesTarget(source.text!, source.number ?? 0);
    return nullablepropertiestarget;
  }
}
```