### PR TITLE
Addded nullChecked support for nullable list

### DIFF
--- a/generator/lib/code_builders/assignment_builder.dart
+++ b/generator/lib/code_builders/assignment_builder.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:smartstruct_generator/models/source_assignment.dart';
@@ -50,16 +51,31 @@ Expression generateSourceFieldAssignment(SourceAssignment sourceAssignment,
         expr = refer(matchingMappingListMethods.first.name);
       }
 
-      sourceFieldAssignment =
-          // source.{field}.map
-          sourceReference
-              .property(sourceField.name)
-              .property('map')
-              // (expr)
-              .call([expr])
-              //.toList()
-              .property('toList')
-              .call([]);
+      if (sourceField.type.isDartCoreList &&
+          sourceField.type.nullabilitySuffix == NullabilitySuffix.question) {
+        sourceFieldAssignment =
+            // source.{field}.map
+            sourceReference
+                .property(sourceField.name)
+                .nullChecked
+                .property('map')
+                // (expr)
+                .call([expr])
+                //.toList()
+                .property('toList')
+                .call([]);
+      } else {
+        sourceFieldAssignment =
+            // source.{field}.map
+            sourceReference
+                .property(sourceField.name)
+                .property('map')
+                // (expr)
+                .call([expr])
+                //.toList()
+                .property('toList')
+                .call([]);
+      }
     } else {
       // found a mapping method in the class which will map the source to target
       final matchingMappingMethods = _findMatchingMappingMethod(

--- a/generator/pubspec.lock
+++ b/generator/pubspec.lock
@@ -7,28 +7,28 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "24.0.0"
+    version: "31.0.0"
   analyzer:
     dependency: "direct main"
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.8.0"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.3.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.1"
   build_config:
     dependency: transitive
     description:
@@ -56,28 +56,28 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.6"
   build_test:
     dependency: transitive
     description:
       name: build_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0"
+    version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.3"
   charcode:
     dependency: transitive
     description:
@@ -98,14 +98,14 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.1"
+    version: "0.3.5"
   code_builder:
     dependency: "direct main"
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   collection:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   crypto:
     dependency: transitive
     description:
@@ -140,14 +140,14 @@ packages:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.0"
+    version: "0.17.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.2.1"
   file:
     dependency: transitive
     description:
@@ -168,21 +168,21 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   html:
     dependency: transitive
     description:
@@ -210,7 +210,7 @@ packages:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
@@ -224,21 +224,21 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.4.0"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -252,7 +252,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   node_preamble:
     dependency: transitive
     description:
@@ -266,14 +266,14 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.2"
   path:
     dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   pedantic:
     dependency: "direct dev"
     description:
@@ -294,21 +294,21 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -322,7 +322,7 @@ packages:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -343,14 +343,14 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   source_gen_test:
     dependency: "direct dev"
     description:
       name: source_gen_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -413,21 +413,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.10"
+    version: "1.20.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.11"
   typed_data:
     dependency: transitive
     description:
@@ -441,14 +441,14 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.1.0"
+    version: "8.1.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
@@ -471,4 +471,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/generator/test/src/list_mapper_input.dart
+++ b/generator/test/src/list_mapper_input.dart
@@ -6,6 +6,12 @@ class ListSource {
   ListSource(this.list);
 }
 
+class NullableListSource {
+  final List<ListSubSource>? list;
+
+  NullableListSource(this.list);
+}
+
 class ListSubSource {
   final String text;
 
@@ -16,6 +22,12 @@ class ListTarget {
   final List<ListSubTarget> list;
 
   ListTarget(this.list);
+}
+
+class NullableListTarget {
+  final List<ListSubSource>? list;
+
+  NullableListTarget(this.list);
 }
 
 class ListSubTarget {
@@ -40,9 +52,17 @@ class ListMapperImpl extends ListMapper {
     final listsubtarget = ListSubTarget(source.text);
     return listsubtarget;
   }
+
+  @override
+  NullableListTarget fromNullableListSource(NullableListSource source) {
+    final nullablelisttarget =
+        NullableListTarget(source.list!.map(fromSubSource).toList());
+    return nullablelisttarget;
+  }
 }
 ''')
 abstract class ListMapper {
   ListTarget fromSource(ListSource source);
   ListSubTarget fromSubSource(ListSubSource source);
+  NullableListTarget fromNullableListSource(NullableListSource source);
 }


### PR DESCRIPTION
I've added nullChecked for nullable list. (Test is failing due to an issue described below).

Generated source is generating:
```
final nullablelisttarget =
        NullableListTarget(source.list!.map((e) => e).toList());
```

It should be

```
final nullablelisttarget =
        NullableListTarget(source.list!.map(fromSubSource).toList());
```

I'm not sure why `matchingMappingListMethods.isNotEmpty` is returning false. 

If you can help me out, I can make changes and push the commit on this PR.
Also, let me know if there are any other changes related to this.