### PR TITLE
Feat/optional static mapping

### DIFF
--- a/example/lib/static_mapping/function_mapping_static.dart
+++ b/example/lib/static_mapping/function_mapping_static.dart
@@ -1,0 +1,50 @@
+import 'package:smartstruct/smartstruct.dart';
+
+part 'function_mapping_static.mapper.g.dart';
+
+// TARGET
+
+class Dog {
+  final String name;
+  final String breed;
+  final int age;
+  late AgeHolderTarget? model;
+
+  Dog(this.name, this.breed, this.age);
+}
+
+// SOURCE
+
+class DogModel {
+  final String name;
+  final int age;
+
+  DogModel(this.name, this.age);
+}
+
+class AgeHolderSource {
+  final int age;
+  AgeHolderSource(this.age);
+}
+
+class AgeHolderTarget {
+  late int age;
+}
+
+// This example uses static helper methods to map inner fields
+@Mapper(useStaticMapping: false)
+abstract class DogMapper {
+  static String breedCustom(DogModel model) => 'customBreed';
+
+  static AgeHolderSource? toAgeHolderSource(DogModel model) =>
+      AgeHolderSource(model.age);
+
+  static String fullNameWithAge(DogModel model) => model.name + '${model.age}';
+
+  @Mapping(source: fullNameWithAge, target: 'name')
+  @Mapping(source: breedCustom, target: 'breed')
+  @Mapping(source: toAgeHolderSource, target: 'model')
+  Dog fromDogModel(DogModel model);
+
+  AgeHolderTarget fromAgeHolderSource(AgeHolderSource model);
+}

--- a/example/lib/static_mapping/function_mapping_static.mapper.g.dart
+++ b/example/lib/static_mapping/function_mapping_static.mapper.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'function_mapping_static.dart';
+
+// **************************************************************************
+// MapperGenerator
+// **************************************************************************
+
+class DogMapperImpl extends DogMapper {
+  DogMapperImpl() : super();
+
+  @override
+  Dog fromDogModel(DogModel model) {
+    final dog = Dog(DogMapper.fullNameWithAge(model),
+        DogMapper.breedCustom(model), model.age);
+    dog.model = () {
+      final tmp = DogMapper.toAgeHolderSource(model);
+      return tmp == null ? null : fromAgeHolderSource(tmp);
+    }();
+    return dog;
+  }
+
+  @override
+  AgeHolderTarget fromAgeHolderSource(AgeHolderSource model) {
+    final ageholdertarget = AgeHolderTarget();
+    ageholdertarget.age = model.age;
+    return ageholdertarget;
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,20 +3,20 @@ description: example
 version: 1.0.1
 # homepage: https://www.example.com
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 publish_to: none
 dependencies:
   freezed_annotation: ^2.1.0
   injectable: ^1.5.3
-  smartstruct: ^1.3.0
+  smartstruct: ^1.4.0
 dev_dependencies:
   build_runner: ^2.1.7
   freezed: ^2.1.0+1
   injectable_generator: ^1.5.3
-  smartstruct_generator: ^1.3.0
+  smartstruct_generator: ^1.4.0
   #smartstruct_generator:
   #  path: ../generator
-dependency_overrides:
-  smartstruct:
-    path: ../smartstruct
+# dependency_overrides:
+#   smartstruct:
+#     path: ../smartstruct

--- a/generator/analysis_options.yaml
+++ b/generator/analysis_options.yaml
@@ -1,5 +1,4 @@
 include: package:lints/recommended.yaml
-
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 
 # Uncomment to specify additional rules.
@@ -10,6 +9,3 @@ include: package:lints/recommended.yaml
 # analyzer:
 #   exclude:
 #     - path/to/excluded/files/**
-analyzer:
-  enable-experiment:
-    - non-nullable

--- a/generator/lib/code_builders/assignment_builder.dart
+++ b/generator/lib/code_builders/assignment_builder.dart
@@ -27,8 +27,8 @@ Expression generateSourceFieldAssignment(SourceAssignment sourceAssignment,
         .map((sourceParam) => refer(sourceParam.displayName));
     Expression expr = refer(sourceFunction.name);
     if (sourceFunction.isStatic &&
-        sourceFunction.enclosingElement3.name != null) {
-      expr = refer(sourceFunction.enclosingElement3.name!)
+        sourceFunction.enclosingElement.name != null) {
+      expr = refer(sourceFunction.enclosingElement.name!)
           .property(sourceFunction.name);
     }
     sourceFieldAssignment = expr.call(
@@ -191,11 +191,11 @@ Iterable<MethodElement> _findMatchingMappingMethod(ClassElement classElement,
     if (met.parameters.isEmpty) {
       return false;
     }
-    final metReturnElement = met.returnType.element2;
-    final metParameterElement = met.parameters.first.type.element2;
+    final metReturnElement = met.returnType.element;
+    final metParameterElement = met.parameters.first.type.element;
 
-    final targetReturnElement = targetReturnType.element2;
-    final srcParameterElement = sourceParameterType.element2;
+    final targetReturnElement = targetReturnType.element;
+    final srcParameterElement = sourceParameterType.element;
 
     return metReturnElement == targetReturnElement &&
         (metParameterElement == srcParameterElement);

--- a/generator/lib/code_builders/class_builder.dart
+++ b/generator/lib/code_builders/class_builder.dart
@@ -30,6 +30,8 @@ List<Class> _generateStaticProxy(
 
 List<Method> _generateStaticMethods(
     ClassElement abstractClass, Map<String, dynamic> config) {
+  if (config['useStaticMapping'] == false) return [];
+
   var staticMethods = abstractClass.methods
       .where(
         (method) =>
@@ -49,7 +51,7 @@ bool _shouldGenerateStaticMethod(MethodElement method) {
 }
 
 bool _isAbstractType(DartType type) {
-  final element = type.element2;
+  final element = type.element;
   if (element is! ClassElement) {
     return false;
   }

--- a/generator/lib/mapper_config.dart
+++ b/generator/lib/mapper_config.dart
@@ -10,7 +10,7 @@ class MapperConfig {
   static Map<String, dynamic> readMapperConfig(
       ConstantReader annotation, ClassElement mappingClass) {
     var mapper =
-        mappingClass.metadata[0].element!.enclosingElement3 as ClassElement;
+        mappingClass.metadata[0].element!.enclosingElement as ClassElement;
     final config = <String, dynamic>{};
 
     for (final field in mapper.fields) {
@@ -37,7 +37,8 @@ class MapperConfig {
   }
 
   static bool isIgnoreMapping(MethodElement method) {
-    final annotations = TypeChecker.fromRuntime(IgnoreMapping).annotationsOf(method);
+    final annotations =
+        TypeChecker.fromRuntime(IgnoreMapping).annotationsOf(method);
     return annotations.isNotEmpty;
   }
 }

--- a/smartstruct/lib/src/annotations.dart
+++ b/smartstruct/lib/src/annotations.dart
@@ -5,8 +5,14 @@ class Mapper {
   final bool useInjection;
   final bool caseSensitiveFields;
   final bool generateStaticProxy;
+  final bool useStaticMapping;
 
-  const Mapper({this.useInjection = false, this.caseSensitiveFields = false, this.generateStaticProxy = false});
+  const Mapper({
+    this.useInjection = false,
+    this.caseSensitiveFields = false,
+    this.generateStaticProxy = false,
+    this.useStaticMapping = true,
+  });
 }
 
 const mapper = Mapper();


### PR DESCRIPTION
This PR adds new parameter to Mapper() annotation to optionally turn off "Static mapping". 

In our project, we usually have "statci helper methods" to map the inner fields of complex objects, but such methods are only for mapping. Without this feature, for each static method a new static $_method is generated which often is not needed and moreover, sometimes it leads to compile errors. 

Breaking change: **NO** - as this parameter is by default set to true