### PR TITLE
Ignore plain getter

### DIFF
--- a/example/lib/complete/complete.dart
+++ b/example/lib/complete/complete.dart
@@ -40,18 +40,8 @@ class FooSource extends SuperFooSource {
   final List<FooNestedSource> list;
   @override
   final String superGet;
-  FooSource(
-      this.number,
-      this.text,
-      this.truthy,
-      this.named,
-      this.setterNumber,
-      this.property,
-      this.propertyTwo,
-      this.namedTwo,
-      this.list,
-      this.superGet,
-      String superText)
+  FooSource(this.number, this.text, this.truthy, this.named, this.setterNumber, this.property, this.propertyTwo,
+      this.namedTwo, this.list, this.superGet, String superText)
       : super(superText);
 }
 
@@ -92,10 +82,7 @@ class BarTarget {
   }
 
   BarTarget(this.numberDiff, this.text, this.truthy, this.superText,
-      {required this.named,
-      required this.namedTwoDiff,
-      required this.list,
-      required this.secondTextOther});
+      {required this.named, required this.namedTwoDiff, required this.list, required this.secondTextOther});
 }
 
 class BarNestedTarget {

--- a/example/lib/complete/complete.mapper.g.dart
+++ b/example/lib/complete/complete.mapper.g.dart
@@ -11,26 +11,34 @@ class ExampleMapperImpl extends ExampleMapper {
   ExampleMapperImpl() : super();
 
   @override
-  BarTarget fromFoo(FooSource source, FooSourceTheSecond second) {
+  BarTarget fromFoo(
+    FooSource source,
+    FooSourceTheSecond second,
+  ) {
     final bartarget = BarTarget(
-        source.number, source.text, source.truthy, source.superText,
-        named: source.named,
-        namedTwoDiff: source.namedTwo,
-        list: source.list.map((x) => fromFooSub(x)).toList(),
-        secondTextOther: second.secondTextOther);
+      source.number,
+      source.text,
+      source.truthy,
+      source.superText,
+      named: source.named,
+      namedTwoDiff: source.namedTwo,
+      list: source.list.map((x) => fromFooSub(x)).toList(),
+      secondTextOther: second.secondTextOther,
+    );
     bartarget.property = source.property;
     bartarget.propertyTwoDiff = source.propertyTwo;
     bartarget.nested = fromFooSub(source.nested);
     bartarget.superPropertySet = source.superPropertySet;
     bartarget.secondText = second.secondText;
-    bartarget.setterTextDiff = source.setterText;
-    bartarget.setterNumber = source.setterNumber;
     return bartarget;
   }
 
   @override
   BarNestedTarget fromFooSub(FooNestedSource source) {
-    final barnestedtarget = BarNestedTarget(source.text, source.number);
+    final barnestedtarget = BarNestedTarget(
+      source.text,
+      source.number,
+    );
     return barnestedtarget;
   }
 }

--- a/example/lib/constructor/constructor.mapper.g.dart
+++ b/example/lib/constructor/constructor.mapper.g.dart
@@ -7,10 +7,17 @@ part of 'constructor.dart';
 // **************************************************************************
 
 class ConstructorMapperImpl extends ConstructorMapper {
-  ConstructorMapperImpl(String? optionalPos, String requiredPos,
-      {required String requiredNamed, String? optionalNamed})
-      : super(optionalPos, requiredPos,
-            requiredNamed: requiredNamed, optionalNamed: optionalNamed);
+  ConstructorMapperImpl(
+    String? optionalPos,
+    String requiredPos, {
+    required String requiredNamed,
+    String? optionalNamed,
+  }) : super(
+          optionalPos,
+          requiredPos,
+          requiredNamed: requiredNamed,
+          optionalNamed: optionalNamed,
+        );
 
   ConstructorMapperImpl.foo(String text) : super.foo(text);
 

--- a/example/lib/field_mapping/field_mapping.mapper.g.dart
+++ b/example/lib/field_mapping/field_mapping.mapper.g.dart
@@ -12,7 +12,11 @@ class DogMapperImpl extends DogMapper {
   @override
   Dog fromDogModel(DogModel model) {
     final dog = Dog(
-        model.dogName, model.breed, model.dogAge, DogMapper._mapDogType(model));
+      model.dogName,
+      model.breed,
+      model.dogAge,
+      DogMapper._mapDogType(model),
+    );
     return dog;
   }
 }

--- a/example/lib/freezed/freezed_mapper.mapper.g.dart
+++ b/example/lib/freezed/freezed_mapper.mapper.g.dart
@@ -11,7 +11,10 @@ class FreezedMapperImpl extends FreezedMapper {
 
   @override
   FreezedTarget fromModel(FreezedSource model) {
-    final freezedtarget = FreezedTarget(model.name, model.age);
+    final freezedtarget = FreezedTarget(
+      model.name,
+      model.age,
+    );
     return freezedtarget;
   }
 }
@@ -21,8 +24,10 @@ class FreezedNamedMapperImpl extends FreezedNamedMapper {
 
   @override
   FreezedNamedTarget fromModel(FreezedNamedSource model) {
-    final freezednamedtarget =
-        FreezedNamedTarget(name: model.name, age: model.age);
+    final freezednamedtarget = FreezedNamedTarget(
+      name: model.name,
+      age: model.age,
+    );
     return freezednamedtarget;
   }
 }

--- a/example/lib/function_mapping/function_mapping.mapper.g.dart
+++ b/example/lib/function_mapping/function_mapping.mapper.g.dart
@@ -11,8 +11,11 @@ class DogMapperImpl extends DogMapper {
 
   @override
   Dog fromDogModel(DogModel model) {
-    final dog = Dog(fullNameWithAge(model), DogMapper.breedCustom(model),
-        FunctionUtils.mapAge(model));
+    final dog = Dog(
+      fullNameWithAge(model),
+      DogMapper.breedCustom(model),
+      FunctionUtils.mapAge(model),
+    );
     return dog;
   }
 }

--- a/example/lib/function_mapping/function_mapping_more.dart
+++ b/example/lib/function_mapping/function_mapping_more.dart
@@ -1,5 +1,5 @@
 import 'package:smartstruct/smartstruct.dart';
-import 'package:smartstruct_example/function_mapping/function_utils.dart';
+
 part 'function_mapping_more.mapper.g.dart';
 
 // TARGET
@@ -33,14 +33,14 @@ class AgeHolderTarget {
 
 // This is a more complex example.
 // The toAgeHolderSource may return a "null" and the nested mapping "fromDogModel"
-// is not accept "null". 
+// is not accept "null".
 // So we need to invoke "toAgeHolderSource" and assign the
 // return the a variable "tmp". And determine whether use the "nested mapping" by
 // case that the value of "tmp" is null or not.
 @Mapper()
 abstract class DogMapper {
   static String breedCustom(DogModel model) => 'customBreed';
-  
+
   @Mapping(source: fullNameWithAge, target: 'name')
   @Mapping(source: breedCustom, target: 'breed')
   @Mapping(source: toAgeHolderSource, target: 'model')

--- a/example/lib/function_mapping/function_mapping_more.mapper.g.dart
+++ b/example/lib/function_mapping/function_mapping_more.mapper.g.dart
@@ -11,8 +11,11 @@ class DogMapperImpl extends DogMapper {
 
   @override
   Dog fromDogModel(DogModel model) {
-    final dog =
-        Dog(fullNameWithAge(model), DogMapper.breedCustom(model), model.age);
+    final dog = Dog(
+      fullNameWithAge(model),
+      DogMapper.breedCustom(model),
+      model.age,
+    );
     dog.model = () {
       final tmp = toAgeHolderSource(model);
       return tmp == null ? null : fromAgeHolderSource(tmp);

--- a/example/lib/function_mapping/function_mapping_with_mapper.mapper.g.dart
+++ b/example/lib/function_mapping/function_mapping_with_mapper.mapper.g.dart
@@ -11,8 +11,10 @@ class PassOnMapperFunctionMapperImpl extends PassOnMapperFunctionMapper {
 
   @override
   ComplexFunctionTarget fromSource(ComplexFunctionSource source) {
-    final complexfunctiontarget =
-        ComplexFunctionTarget(mapComplexSubSource(source, mapper: this));
+    final complexfunctiontarget = ComplexFunctionTarget(mapComplexSubSource(
+      source,
+      mapper: this,
+    ));
     return complexfunctiontarget;
   }
 

--- a/example/lib/getter/getter_mapper.dart
+++ b/example/lib/getter/getter_mapper.dart
@@ -1,0 +1,40 @@
+import 'package:smartstruct/smartstruct.dart';
+
+part 'getter_mapper.mapper.g.dart';
+
+class GetterTarget {
+  final String name;
+  final int age;
+
+  int foo = 0;
+
+  GetterTarget({
+    required this.name,
+    required this.age,
+  });
+
+  List<Object?> get props => [name, age];
+
+  bool get sample => false;
+}
+
+class GetterSource {
+  final String name;
+  final int age;
+
+  int foo = 1;
+
+  GetterSource({
+    required this.name,
+    required this.age,
+  });
+
+  List<Object?> get props => [name, age];
+
+  bool get sample => true;
+}
+
+@Mapper()
+abstract class GetterMapper {
+  GetterTarget fromModel(GetterSource source);
+}

--- a/example/lib/getter/getter_mapper.mapper.g.dart
+++ b/example/lib/getter/getter_mapper.mapper.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'getter_mapper.dart';
+
+// **************************************************************************
+// MapperGenerator
+// **************************************************************************
+
+class GetterMapperImpl extends GetterMapper {
+  GetterMapperImpl() : super();
+
+  @override
+  GetterTarget fromModel(GetterSource source) {
+    final gettertarget = GetterTarget(
+      name: source.name,
+      age: source.age,
+    );
+    gettertarget.foo = source.foo;
+    return gettertarget;
+  }
+}

--- a/example/lib/inheritance/inheritance.mapper.g.dart
+++ b/example/lib/inheritance/inheritance.mapper.g.dart
@@ -12,7 +12,11 @@ class InheritanceMapperImpl extends InheritanceMapper {
   @override
   BarTarget fromFoo(FooSource source) {
     final bartarget = BarTarget(
-        source.subFoo, source.superFoo, source.mappable, source.superProp);
+      source.subFoo,
+      source.superFoo,
+      source.mappable,
+      source.superProp,
+    );
     return bartarget;
   }
 }

--- a/example/lib/injection/service_locator.config.dart
+++ b/example/lib/injection/service_locator.config.dart
@@ -13,9 +13,16 @@ import 'injectable_mapper.dart' as _i4; // ignore_for_file: unnecessary_lambdas
 
 // ignore_for_file: lines_longer_than_80_chars
 /// initializes the registration of provided dependencies inside of [GetIt]
-_i1.GetIt $initGetIt(_i1.GetIt get,
-    {String? environment, _i2.EnvironmentFilter? environmentFilter}) {
-  final gh = _i2.GetItHelper(get, environment, environmentFilter);
+_i1.GetIt $initGetIt(
+  _i1.GetIt get, {
+  String? environment,
+  _i2.EnvironmentFilter? environmentFilter,
+}) {
+  final gh = _i2.GetItHelper(
+    get,
+    environment,
+    environmentFilter,
+  );
   gh.lazySingleton<_i3.ExampleMapper>(() => _i3.ExampleMapperImpl());
   gh.lazySingleton<_i4.InjectableNestedMapper>(
       () => _i4.InjectableNestedMapperImpl());

--- a/example/lib/list/list.mapper.g.dart
+++ b/example/lib/list/list.mapper.g.dart
@@ -11,8 +11,10 @@ class ListMapperImpl extends ListMapper {
 
   @override
   Target fromSource(Source source) {
-    final target = Target(source.intList.map((e) => e).toList(),
-        source.entryList.map((x) => fromSourceEntry(x)).toList());
+    final target = Target(
+      source.intList.map((e) => e).toList(),
+      source.entryList.map((x) => fromSourceEntry(x)).toList(),
+    );
     return target;
   }
 

--- a/example/lib/list/nullable_list.mapper.g.dart
+++ b/example/lib/list/nullable_list.mapper.g.dart
@@ -12,8 +12,9 @@ class NullableListMapperImpl extends NullableListMapper {
   @override
   NullableListTarget fromSource(NullableListSource source) {
     final nullablelisttarget = NullableListTarget(
-        source.list?.map(fromSubSource).toList(),
-        source.list2?.map(fromSubSource).toList() ?? []);
+      source.list?.map((x) => fromSubSource(x)).toList(),
+      source.list2?.map((x) => fromSubSource(x)).toList() ?? [],
+    );
     return nullablelisttarget;
   }
 

--- a/example/lib/mapper_inheritance/mapper_inheritance.mapper.g.dart
+++ b/example/lib/mapper_inheritance/mapper_inheritance.mapper.g.dart
@@ -16,7 +16,10 @@ class UserLoginContractFromEntityMapperImpl
       return null;
     }
     ;
-    final userlogincontract = UserLoginContract(entity.age, entity.id);
+    final userlogincontract = UserLoginContract(
+      entity.age,
+      entity.id,
+    );
     return userlogincontract;
   }
 }
@@ -31,7 +34,10 @@ class UserLoginContractFromEntityMapper2Impl
       return null;
     }
     ;
-    final userlogincontract2 = UserLoginContract2(entity.age, entity.id);
+    final userlogincontract2 = UserLoginContract2(
+      entity.age,
+      entity.id,
+    );
     return userlogincontract2;
   }
 }

--- a/example/lib/multi_constructor/multi_constructor.mapper.g.dart
+++ b/example/lib/multi_constructor/multi_constructor.mapper.g.dart
@@ -11,7 +11,10 @@ class MultiConMapperImpl extends MultiConMapper {
 
   @override
   MultiConTarget fromSource(MultiConSource source) {
-    final multicontarget = MultiConTarget.multi(source.text, source.number);
+    final multicontarget = MultiConTarget.multi(
+      source.text,
+      source.number,
+    );
     return multicontarget;
   }
 }

--- a/example/lib/multiple_sources/multiple_sources.mapper.g.dart
+++ b/example/lib/multiple_sources/multiple_sources.mapper.g.dart
@@ -10,9 +10,21 @@ class MultipleSourcesMapperImpl extends MultipleSourcesMapper {
   MultipleSourcesMapperImpl() : super();
 
   @override
-  Target fromSource(Source source, Source2 source2, Source3 source3) {
-    final target = Target(source.text1, source2.text2, source3.text3,
-        allText(source, source2, source3));
+  Target fromSource(
+    Source source,
+    Source2 source2,
+    Source3 source3,
+  ) {
+    final target = Target(
+      source.text1,
+      source2.text2,
+      source3.text3,
+      allText(
+        source,
+        source2,
+        source3,
+      ),
+    );
     return target;
   }
 }

--- a/example/lib/nested/nested_mapping.mapper.g.dart
+++ b/example/lib/nested/nested_mapping.mapper.g.dart
@@ -11,8 +11,11 @@ class UserMapperImpl extends UserMapper {
 
   @override
   User fromResponse(UserResponse response) {
-    final user = User(response.username, response.address.zipcode,
-        response.address.street.streetName);
+    final user = User(
+      response.username,
+      response.address.zipcode,
+      response.address.street.streetName,
+    );
     return user;
   }
 }

--- a/example/lib/static_mapping/static_mapping.mapper.g.dart
+++ b/example/lib/static_mapping/static_mapping.mapper.g.dart
@@ -11,12 +11,18 @@ class StaticMappingMapperImpl extends StaticMappingMapper {
 
   @override
   StaticMappingTarget fromSourceNormal(StaticMappingSource source) {
-    final staticmappingtarget = StaticMappingTarget(source.text, source.number);
+    final staticmappingtarget = StaticMappingTarget(
+      source.text,
+      source.number,
+    );
     return staticmappingtarget;
   }
 }
 
 StaticMappingTarget _$fromSourceStatic(StaticMappingSource source) {
-  final staticmappingtarget = StaticMappingTarget(source.text, source.number);
+  final staticmappingtarget = StaticMappingTarget(
+    source.text,
+    source.number,
+  );
   return staticmappingtarget;
 }

--- a/example/lib/static_mapping/static_proxy.mapper.g.dart
+++ b/example/lib/static_mapping/static_proxy.mapper.g.dart
@@ -11,7 +11,10 @@ class StaticMappingMapperImpl extends StaticMappingMapper {
 
   @override
   StaticProxyTarget fromSourceNormal(StaticMappingSource source) {
-    final staticproxytarget = StaticProxyTarget(source.text, source.number);
+    final staticproxytarget = StaticProxyTarget(
+      source.text,
+      source.number,
+    );
     return staticproxytarget;
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "47.0.0"
+    version: "50.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.7.0"
+    version: "5.2.0"
   args:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.11"
+    version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.4.0"
   collection:
     dependency: transitive
     description:
@@ -154,7 +154,7 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0+1"
+    version: "2.1.1"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -168,7 +168,7 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "3.2.0"
   get_it:
     dependency: transitive
     description:
@@ -210,14 +210,14 @@ packages:
       name: injectable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.3"
+    version: "1.5.4"
   injectable_generator:
     dependency: "direct dev"
     description:
       name: injectable_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.4"
+    version: "1.5.5"
   io:
     dependency: transitive
     description:
@@ -238,7 +238,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "4.8.0"
   logging:
     dependency: transitive
     description:
@@ -326,17 +326,17 @@ packages:
   smartstruct:
     dependency: "direct main"
     description:
-      name: smartstruct
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+      path: "../smartstruct"
+      relative: true
+    source: path
+    version: "1.4.0"
   smartstruct_generator:
     dependency: "direct dev"
     description:
       name: smartstruct_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   source_gen:
     dependency: transitive
     description:
@@ -422,4 +422,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/generator/lib/generators/mapper_generator.dart
+++ b/generator/lib/generators/mapper_generator.dart
@@ -1,24 +1,19 @@
-import 'dart:collection';
-
-import 'package:analyzer/dart/element/type.dart';
-import 'package:build/src/builder/build_step.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:build/src/builder/build_step.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:smartstruct/smartstruct.dart';
 import 'package:smartstruct_generator/code_builders/class_builder.dart';
 import 'package:source_gen/source_gen.dart';
+
 import '../mapper_config.dart';
 
 /// Codegenerator to generate implemented mapping classes
 class MapperGenerator extends GeneratorForAnnotation<Mapper> {
   @override
-  dynamic generateForAnnotatedElement(
-      Element element, ConstantReader annotation, BuildStep buildStep) {
+  dynamic generateForAnnotatedElement(Element element, ConstantReader annotation, BuildStep buildStep) {
     if (element is! ClassElement) {
-      throw InvalidGenerationSourceError(
-          '${element.displayName} is not a class and cannot be annotated with @Mapper',
-          element: element,
-          todo: 'Add Mapper annotation to a class');
+      throw InvalidGenerationSourceError('${element.displayName} is not a class and cannot be annotated with @Mapper',
+          element: element, todo: 'Add Mapper annotation to a class');
     }
 
     var config = MapperConfig.readMapperConfig(annotation, element);

--- a/generator/lib/models/NestMapping.dart
+++ b/generator/lib/models/NestMapping.dart
@@ -1,9 +1,7 @@
-
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 
 class NestMapping {
-
   final MethodElement method;
   final VariableElement input;
   late final bool returnNullable;
@@ -17,9 +15,8 @@ class NestMapping {
     inputNullable = input.type.nullabilitySuffix == NullabilitySuffix.question;
     methodParamterNullable = method.parameters.first.type.nullabilitySuffix == NullabilitySuffix.question;
 
-    returnNullable = 
-      (inputNullable && !methodParamterNullable) ||     // 'a == null ? null : call(a)'. So the output is nullable.
-      (inputNullable && methodReturnNullable);          // if input is not null, the method return is not
+    returnNullable =
+        (inputNullable && !methodParamterNullable) || // 'a == null ? null : call(a)'. So the output is nullable.
+            (inputNullable && methodReturnNullable); // if input is not null, the method return is not
   }
-
 }

--- a/generator/test/mapper_test.dart
+++ b/generator/test/mapper_test.dart
@@ -1,6 +1,6 @@
+import 'package:path/path.dart' as p;
 import 'package:smartstruct_generator/generators/mapper_generator.dart';
 import 'package:source_gen_test/source_gen_test.dart';
-import 'package:path/path.dart' as p;
 
 Future<void> main() async {
   initializeBuildLogTracking();
@@ -43,4 +43,5 @@ const _expectedAnnotatedTests = {
   'PassOnMapperFunctionMapper',
   'StaticProxyMapper',
   'MapperInheritanceMapper',
+  'ExplicitGetterMapper',
 };

--- a/generator/test/src/getter_field_mapper_input.dart
+++ b/generator/test/src/getter_field_mapper_input.dart
@@ -1,0 +1,53 @@
+part of 'mapper_test_input.dart';
+
+class GetterTarget {
+  final String name;
+  final int age;
+
+  int foo = 0;
+
+  GetterTarget({
+    required this.name,
+    required this.age,
+  });
+
+  List<Object?> get props => [name, age];
+
+  bool get sample => false;
+}
+
+class GetterSource {
+  final String name;
+  final int age;
+
+  int foo = 1;
+
+  GetterSource({
+    required this.name,
+    required this.age,
+  });
+
+  List<Object?> get props => [name, age];
+
+  bool get sample => true;
+}
+
+@Mapper()
+@ShouldGenerate(r'''
+class ExplicitGetterMapperImpl extends ExplicitGetterMapper {
+  ExplicitGetterMapperImpl() : super();
+
+  @override
+  GetterTarget fromModel(GetterSource source) {
+    final gettertarget = GetterTarget(
+      name: source.name,
+      age: source.age,
+    );
+    gettertarget.foo = source.foo;
+    return gettertarget;
+  }
+}
+''')
+abstract class ExplicitGetterMapper {
+  GetterTarget fromModel(GetterSource source);
+}

--- a/generator/test/src/mapper_test_input.dart
+++ b/generator/test/src/mapper_test_input.dart
@@ -8,6 +8,7 @@ part 'collection_mapper_input.dart';
 part 'constructor_mapper_input.dart';
 part 'explicit_field_mapper_input.dart';
 part 'function_mapper_input.dart';
+part 'getter_field_mapper_input.dart';
 part 'ignore_field_mapper_input.dart';
 part 'inheritance_mapper_input.dart';
 part 'injectable_mapper_input.dart';


### PR DESCRIPTION
If `target` class contains getters, they are included in generated code. This PR change that. 

Fixes #84 